### PR TITLE
4.1.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.0-beta.1
+* The kidding schedule now acceses reference goats when identifying dams and sires
+  * This currently works even if you have disabled the references page on your site, that behavior may change in the future
+
 ## 4.0.0-beta.1
 * Added Support for references!
   * This is intended for animals that are not in the herd but are related to the herd (animals you have on lease, deceased animals that still have a genetic impact on your herd, etc.)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-ui",
-  "version": "4.0.0-beta.1",
+  "version": "4.1.0-beta.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --port 4000",

--- a/src/app/elements/breeding/breeding.component.ts
+++ b/src/app/elements/breeding/breeding.component.ts
@@ -9,13 +9,14 @@ import type { Goat, Kidding } from '../../services/goat/goat.service';
 export class BreedingComponent implements OnChanges {
   ngOnChanges() {
     if (this.breeding) {
-      this.dam = this.does?.find(goat => goat.normalizeId === this.breeding!.dam) ?? { name: this.breeding.dam };
-      this.sire = this.bucks?.find(goat => goat.normalizeId === this.breeding!.sire) ?? { name: this.breeding.sire };
+      this.dam = this.does?.find(goat => goat.normalizeId === this.breeding!.dam) ?? this.references?.find(goat => goat.normalizeId === this.breeding!.dam) ?? { name: this.breeding.dam };
+      this.sire = this.bucks?.find(goat => goat.normalizeId === this.breeding!.sire) ?? this.references?.find(goat => goat.normalizeId === this.breeding!.sire) ?? { name: this.breeding.sire };
     }
   }
   @Input() breeding?: Kidding;
   @Input() does?: Goat[];
   @Input() bucks?: Goat[];
+  @Input() references?: Goat[];
 
   dam?: Goat;
   sire?: Goat;

--- a/src/app/pages/kidding-schedule/kidding-schedule.component.html
+++ b/src/app/pages/kidding-schedule/kidding-schedule.component.html
@@ -4,7 +4,7 @@
   <div *ngIf="schedule">
     <app-modal-goat *ngIf="searchParam && activeIndex === -1" [goat]="activeGoat" [searchParam]="searchParam!"></app-modal-goat>
     <div *ngFor="let breeding of schedule; index as i">
-      <app-breeding [breeding]="breeding" [does]="does" [bucks]="bucks"></app-breeding>
+      <app-breeding [breeding]="breeding" [does]="does" [bucks]="bucks" [references]="references"></app-breeding>
       <app-modal-goat *ngIf="i === activeIndex" [goat]="activeGoat" [searchParam]="searchParam!"></app-modal-goat>
     </div>
   </div>

--- a/src/app/pages/kidding-schedule/kidding-schedule.component.spec.ts
+++ b/src/app/pages/kidding-schedule/kidding-schedule.component.spec.ts
@@ -17,7 +17,8 @@ describe('KiddingScheduleComponent', () => {
     goatServiceMock = {
       kidding: of([]),
       does: of([]),
-      bucks: of([])
+      bucks: of([]),
+      references: of([])
     };
 
     routeMock = {

--- a/src/app/pages/kidding-schedule/kidding-schedule.component.ts
+++ b/src/app/pages/kidding-schedule/kidding-schedule.component.ts
@@ -18,6 +18,7 @@ export class KiddingScheduleComponent implements OnInit, Page {
   public noSchedule = false;
   public does?: Goat[];
   public bucks?: Goat[];
+  public references?: Goat[];
   public activeGoat?: Goat;
   public searchParam?: string;
   public activeIndex?: number;
@@ -57,6 +58,12 @@ export class KiddingScheduleComponent implements OnInit, Page {
       next: bucks => {
         this.bucks = bucks;
         this.determineActiveGoat(bucks);
+      }
+    });
+    this.goatService.references.subscribe({
+      next: references => {
+        this.references = references;
+        this.determineActiveGoat(references);
       }
     });
   }


### PR DESCRIPTION
## 4.1.0-beta.1
* The kidding schedule now acceses reference goats when identifying dams and sires
  * This currently works even if you have disabled the references page on your site, that behavior may change in the future
