### PR TITLE
5.3.4-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.3.4-beta.2
+* Fixed a bug causing the markdown for goats to be re-rendered when the goat is opened
+
 ## 5.3.4-beta.1
 * Added support for Markdown rendering in the live preview! This even works offline!
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-ui",
-  "version": "5.3.4-beta.1",
+  "version": "5.3.4-beta.2",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --port 4000",

--- a/src/app/elements/goat-card/goat-card.component.html
+++ b/src/app/elements/goat-card/goat-card.component.html
@@ -17,7 +17,7 @@
       <h6 class="card-subtitle pb-1 text-center" *ngIf="nickname" test-id="goat-nickname">"{{nickname}}"</h6>
       <h6 class="card-subtitle pb-1 text-center" *ngIf="price" test-id="goat-price">{{price}}</h6>
       <div class="card-text text-center text-truncate-3 pt-1" *ngIf="description" [innerHTML]="description" test-id="goat-description"
-        [markdown]="identifier ? 'goat-'+(goat.id || goat.name || goat.nickname) : ''">
+        [markdown]="(id || name || nickname) ? 'goat-'+(id || name || nickname) : ''">
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 5.3.4-beta.2
* Fixed a bug causing the markdown for goats to be re-rendered when the goat is opened
