### PR TITLE
5.4.5-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.4.5-beta.1
+* "Not Found" modals now set the `noindex` meta tag to prevent search engines from indexing the page
+
 ## 5.4.4-beta.1
 * Added support for the `First Input Delay` metric in the performance report
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-ui",
-  "version": "5.4.4-beta.1",
+  "version": "5.4.5-beta.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --port 4000",

--- a/src/app/elements/modal/not-found/__snapshots__/not-found.component.spec.ts.snap
+++ b/src/app/elements/modal/not-found/__snapshots__/not-found.component.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`NotFoundComponent should match the snapshot 1`] = `
 <app-modal-not-found
+  meta={[Function _Meta]}
   searchParam={[Function String]}
 >
   <h5

--- a/src/app/elements/modal/not-found/not-found.component.ts
+++ b/src/app/elements/modal/not-found/not-found.component.ts
@@ -1,11 +1,19 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, type OnDestroy, type OnInit } from '@angular/core';
+import { Meta } from '@angular/platform-browser';
 
 @Component({
-    selector: 'app-modal-not-found',
-    templateUrl: './not-found.component.html',
-    styleUrl: './not-found.component.scss',
-    standalone: false
+  selector: 'app-modal-not-found',
+  templateUrl: './not-found.component.html',
+  styleUrl: './not-found.component.scss',
+  standalone: false
 })
-export class NotFoundComponent {
+export class NotFoundComponent implements OnInit, OnDestroy {
   @Input({ required: true }) searchParam!: string;
+  constructor(private meta: Meta) { }
+  ngOnInit(): void {
+    this.meta.addTag({ name: 'robots', content: 'noindex' });
+  }
+  ngOnDestroy(): void {
+    this.meta.removeTag('name="robots"');
+  }
 }


### PR DESCRIPTION
## 5.4.5-beta.1
* "Not Found" modals now set the `noindex` meta tag to prevent search engines from indexing the page
