### PR TITLE
5.6.4-beta.3

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Commit Changes
         id: commit
-        run:
+        run: |
           git config --global user.name "Digi"
           git config --global user.email "DigiGoat@LilPilchuckCreek.org"
           git commit -am "Synced website"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.6.4-beta.3
+* Added missing `|` that was preventing the commit step of the sync workflow from running
+
 ## 5.6.4-beta.2
 * Updated the adga dependency to try to fix a sync error
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-ui",
-  "version": "5.6.4-beta.2",
+  "version": "5.6.4-beta.3",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --port 4000",


### PR DESCRIPTION
## 5.6.4-beta.3
* Added missing `|` that was preventing the commit step of the sync workflow from running
