### PR TITLE
5.6.5-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.6.5-beta.1
+* Reverted `5.6.1-beta.1` as it was causing issues with the sync workflow. The adga package is now automatically stripped of the beta tag during the release process again.
+
 ## 5.6.4-beta.4
 * Modified how the sync workflow records if there are changes to remove some breaking errors
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-ui",
-  "version": "5.6.4-beta.4",
+  "version": "5.6.5-beta.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --port 4000",
@@ -57,7 +57,7 @@
     "@types/semver": "^7.5.8",
     "@typescript-eslint/eslint-plugin": "7.2.0",
     "@typescript-eslint/parser": "7.2.0",
-    "adga": "^3.8.0-beta.1",
+    "adga": "^3.8.0",
     "axios": "^1.6.8",
     "chalk": "4",
     "eslint": "^8.57.0",

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -2,4 +2,5 @@ import { readFileSync, writeFileSync } from 'fs';
 
 const packageJson = JSON.parse(readFileSync('package.json', 'utf8'));
 packageJson.version = packageJson.version.split('-')[0];
+packageJson.devDependencies.adga = packageJson.devDependencies.adga.split('-')[0];
 writeFileSync('package.json', JSON.stringify(packageJson, null, 2));

--- a/yarn.lock
+++ b/yarn.lock
@@ -3125,10 +3125,10 @@ acorn@^8.1.0, acorn@^8.4.1, acorn@^8.8.1, acorn@^8.9.0:
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz"
   integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
 
-adga@^3.8.0-beta.1:
-  version "3.8.0-beta.1"
-  resolved "https://registry.yarnpkg.com/adga/-/adga-3.8.0-beta.1.tgz#73531ee3f42c526e59a93e15dc1aee3f0935a25f"
-  integrity sha512-zCBqWbI4nPSUyjyyto82LSifwu3XvX5SC6O3vVR0xAxzxFwjErl69Gpz2Tv2T5cAezxlWNjalCTvX0H9jorLJw==
+adga@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/adga/-/adga-3.8.0.tgz#458fe16c371e1bdafa66b9d9ffdc48ab08696c74"
+  integrity sha512-FqoNH4PSXFTQHiceBJQ2+DbAW73LUXqmJGv37gg9IHoOt/9dIXw0fzHUxk2wZYF2VfgmOqVNq0c9fLLN6+tzxQ==
   dependencies:
     axios "^0.26.1"
 


### PR DESCRIPTION
## 5.6.5-beta.1
* Reverted `5.6.1-beta.1` as it was causing issues with the sync workflow. The adga package is now automatically stripped of the beta tag during the release process again.
